### PR TITLE
insecure ssl/tls

### DIFF
--- a/connekt-script-definition/src/main/java/io/amplicode/connekt/dsl/SslExtenstions.kt
+++ b/connekt-script-definition/src/main/java/io/amplicode/connekt/dsl/SslExtenstions.kt
@@ -6,6 +6,7 @@ import java.security.KeyStore
 import java.security.SecureRandom
 import java.security.cert.Certificate
 import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
@@ -83,4 +84,32 @@ fun OkHttpClient.Builder.addKeyStore(keyStoreFile: File, keystorePassword: Strin
         sslContext.socketFactory,
         trustManager
     )
+}
+
+/**
+ * Configures the [OkHttpClient.Builder] so that SSL/TLS certificate verification is disabled.
+ *
+ * This method creates a trust-all-certificates [X509TrustManager] which accepts any certificate.
+ * Using this configuration makes your application vulnerable to man-in-the-middle attacks because it
+ * will accept invalid or untrusted certificates.
+ *
+ * **IMPORTANT:** NEVER USE THIS METHOD IN PRODUCTION! Disabling SSL certificate validation exposes sensitive data
+ * and can lead to security breaches.
+ */
+fun OkHttpClient.Builder.insecure() {
+
+    val trustAllCerts = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+
+        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+
+        override fun getAcceptedIssuers(): Array<out X509Certificate>? = emptyArray()
+    }
+
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.init(null, arrayOf(trustAllCerts), SecureRandom())
+
+
+    sslSocketFactory(sslContext.socketFactory, trustAllCerts)
+
 }

--- a/connekt-script-definition/src/test/java/io/amplicode/connekt/SslTest.kt
+++ b/connekt-script-definition/src/test/java/io/amplicode/connekt/SslTest.kt
@@ -3,6 +3,7 @@ package io.amplicode.connekt
 import io.amplicode.connekt.dsl.GET
 import io.amplicode.connekt.dsl.addX509Certificate
 import io.amplicode.connekt.dsl.addKeyStore
+import io.amplicode.connekt.dsl.insecure
 import io.amplicode.connekt.test.utils.server.ServerSslParams
 import io.amplicode.connekt.test.utils.server.TestServer
 import io.amplicode.connekt.test.utils.asUnit
@@ -107,6 +108,17 @@ class SslTest(server: TestServer) : TestWithServer(server) {
     fun `self-signed pem via ext function`() = runScript {
         configureClient {
             addX509Certificate(sslParams.certPemFile)
+        }
+
+        GET("$hostHttps/foo") then {
+            assertEquals("foo", body?.string())
+        }
+    }.asUnit()
+
+    @Test
+    fun `insecure via ext function`() = runScript {
+        configureClient {
+            insecure()
         }
 
         GET("$hostHttps/foo") then {


### PR DESCRIPTION
Hello!
Sometimes, during the development process, you need to send requests to web services with self-signed certificates. 
This is a one-time task to get a resource and it doesn't make sense to add a certificate to the keystore or create a certificate file. 
To do this, `cURL` has the `--insecure` parameter. I suggest adding in to `SslExtenstions.kt` is an `OkHttpClient.Builder.insecure()` extension function. I propose the following this is implementation.